### PR TITLE
Resolve bug that can't show hidden window between different tag

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -2760,6 +2760,10 @@ restorewin(const Arg *arg) {
             show(hiddenWinStack[i]);
             focus(hiddenWinStack[i]);
             restack(selmon);
+            // need set j<hiddenWinStackTop+1. Because show will reduce hiddenWinStackTop value.
+            for (int j = i; j < hiddenWinStackTop+1; ++j) {
+                hiddenWinStack[j] = hiddenWinStack[j + 1];
+            }
             return;
         }
         --i;


### PR DESCRIPTION
解决了不能跨桌面显示隐藏窗口的Bug
Bug 复现：
> 1. 在tag1内开三个终端
> 2. 在tag2内开三个终端
> 3. 回到tag1 连续两次win+h隐藏掉两个终端
> 4. 回到tag2 连续两次win+h隐藏掉两个终端
> 5. 回到tag1 连续两次win+shift+h 恢复两个终端
>  以上一切都是正常的，隐藏和恢复都没有问题，但下面就不行了
> 6. 回到tag2 发现这时候win+shfit+h 无法恢复tag2下的隐藏终端了

