### PR TITLE
音乐标题包含"'时的处理

### DIFF
--- a/DEF/statusbar/packages/music.sh
+++ b/DEF/statusbar/packages/music.sh
@@ -13,12 +13,16 @@ signal=$(echo "^s$this^" | sed 's/_//')
 update() {
     music_text="$(mpc current)"
     icon=" 󰝚 "
-    text=" $music_text "
+    if $music_text=~"\""; then
+        text=$(echo $music_text | sed -e "s/\"\\\\\"/g")
+    else
+        text=" $music_text "
+    fi
     [ "$(mpc status | grep "paused")" ] && icon=" 󰐎 "
 
     sed -i '/^export '$this'=.*$/d' $tempfile
     [ ! "$music_text" ] && return
-    printf "export %s='%s%s%s%s%s'\n" $this "$signal" "$icon_color" "$icon" "$text_color" "$text" >> $tempfile
+    printf "export %s=\"%s%s%s%s%s\"\n" $this "$signal" "$icon_color" "$icon" "$text_color" "$text" >> $tempfile
 }
 
 click() {


### PR DESCRIPTION
当音乐标题包含"'时的temp里export _music时会报错
该提交处理了此特殊情况，会将字符转义处理
