### PR TITLE
fix: logic of apply relus

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -444,8 +444,8 @@ applyrules(Client *c)
         r = &rules[i];
         // 当rule中定义了一个或多个属性时，只要有一个属性匹配，就认为匹配成功
         if ((r->title && strstr(c->name, r->title))
-                || (r->class && strstr(class, r->class))
-                || (r->instance && strstr(instance, r->instance)))
+                || (r->class && !strcmp(class, r->class))
+                || (r->instance && !strcmp(instance, r->instance)))
         {
             c->isfloating = r->isfloating;
             c->isglobal = r->isglobal;


### PR DESCRIPTION
后面两种似乎判断相等好点，不排除有些软件的名称是其他软件的子串，比如`obs`和`obsidian`。在rules中将`obsidian`定义在`obs`之前似乎也可以解决这个问题，但是这种隐式的规则对用户来说感觉不太友好。