### PR TITLE
fix: 切换边框时，只有一个窗口就不能切换边框颜色

### DIFF
--- a/dwm.c
+++ b/dwm.c
@@ -2864,8 +2864,20 @@ toggleglobal(const Arg *arg)
 void
 toggleborder(const Arg *arg)
 {
+    int client_count = 0;
+    Client *c = NULL;
+    // 判断当前是否选中客户端
     if (!selmon->sel)
         return;
+    // 判断是否只有一个窗口
+    for (c = selmon->clients; c; c = c->next) {
+        if (ISVISIBLE(c) && !HIDDEN(c)) {
+            client_count ++;
+        }
+    }
+    if (client_count == 1) {
+        return;
+    }
     selmon->sel->isnoborder ^= 1;
     selmon->sel->bw = selmon->sel->isnoborder ? 0 : borderpx;
     int diff = (selmon->sel->isnoborder ? -1 : 1) * borderpx;


### PR DESCRIPTION
但只有一个窗口的时候，窗口是没有边框的，所以一直切换时，窗口会跑出屏幕外，所以但只有一个窗口时不能切换边框

切换前：
![切换边框前](https://github.com/yaocccc/dwm/assets/47386021/58234611-b30d-4b90-a552-45aa19c4f55e)

切换后：
![切换边框后](https://github.com/yaocccc/dwm/assets/47386021/5079a489-8908-47e2-b07b-56d81d72e6ef)
